### PR TITLE
MyISAM key limit requires utf8mb4 index limit of 250 characters

### DIFF
--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -414,7 +414,7 @@ CREATE TABLE tls906_person (
   PRIMARY KEY (person_id),
   KEY IX_ppat_person_ctry_code (person_ctry_code),
   KEY IX_ppat_han_id (han_id),
-  KEY IX_han_name (han_name(333)),
+  KEY IX_han_name (han_name(250)),
   KEY IX_han_harmonized (han_harmonized)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=100;
 
@@ -434,8 +434,8 @@ CREATE TABLE tls909_eee_ppat (
   pat_cnt int(11) NOT NULL,
   PRIMARY KEY (person_id),
   KEY IX_ppat_person_ctry_code (person_ctry_code),
-  KEY IX_ppat_hrm_l1 (hrm_l1(333)),
-  KEY IX_ppat_hrm_l2 (hrm_l2(333)),
+  KEY IX_ppat_hrm_l1 (hrm_l1(250)),
+  KEY IX_ppat_hrm_l2 (hrm_l2(250)),
   KEY IX_ppat_sector (sector),
   KEY IX_ppat_hrm_l2_id (hrm_l2_id)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=100;


### PR DESCRIPTION
Because utf8mb4 characters take up 4 bytes instead of 3, use index sizes of 250 characters instead of 333 (max index size is 1000 bytes for MyISAM tables).

See [1] for documentation on the charset utf8mb4 byte size, [2] for documentation on the MyISAM maximum key length and how to change it (need to recompile MySQL), [3] and [4] for infos on how to change the max key length in InnoDB, using a startup option.

For the long term, it may be worth to think about switching to the InnoDB engine for the entire database. MyISAM seems to be mostly superseded by InnoDB. InnoDB used to be slower than MyISAM, but with a recent version of MySQL, this does not seem to hold anymore, see [5]. Maybe MyISAM is needed for the read-only DB compression, but I'm not sure what benefits this brings, apart from taking up less space. If space is not an issue, maybe a saner solution would be to upgrade to InnoDB and using a larger maximum key length? This would allow to fit the entire VARCHAR(500) field into the index, since the maximum length is 3072 bytes.

[1]: https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html
[2]: https://dev.mysql.com/doc/refman/5.7/en/myisam-storage-engine.html
[3]: https://dba.stackexchange.com/questions/49913/specified-key-was-too-long-max-key-length-is-1000-bytes-in-mysql-5-6
[4]: https://dev.mysql.com/doc/refman/5.6/en/innodb-parameters.html#sysvar_innodb_large_prefix
[5]: https://stackoverflow.com/questions/7492771/should-i-use-myisam-or-innodb-tables-for-my-mysql-database