### PR TITLE
Patstat 2016b compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ PATSTAT is shipped as a bunch of zipped, csv files spread across multiple DVDs. 
 
 This utility wants to make it easy for everyone to build a *PATSTAT MySQL* database from raw csv data. To achieve high-performances, database tables are compressed.
 
-Currently, there is full compatibility with version Spring 2016, also known as 2016a.
+This version on branch patstat_2016b has full compatibility with version Autumn 2016, also known as 2016b.
+
+Currently, the master branch has full compatibility with version Spring 2016, also known as 2016a.
 
 ~~The utility is also capable of loading the standardized EEE-PPAT person table with harmonized assignee names and assignee sector allocations (https://www.ecoom.be/en/EEE-PPAT). This table has been officially included in version 2015a.~~ This is untested, as I do not have this database.
 
@@ -33,18 +35,27 @@ Usage: [-v] [-t] -u mysql_user -p mysql_pass -h mysql_host -d mysql_dbname -z pa
 
 Examples
 --------
-Load a **test** PASTSTAT database and the standardized person table into a MySQL database on `localhost` named `patstat_2016a` -- note the `-t` modifier. Zipped table files have been placed into the default folder `./data`.
+Load a **test** PASTSTAT database and the standardized person table into a MySQL database on `localhost` named `patstat_2016b` -- note the `-t` modifier. Zipped table files have been placed into the default folder `./data`.
 
 ```
-$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat_2016a -t -n
+$ ./load_patstat.sh -u <USER> -p <PASSWORD> -h localhost -d patstat_2016b -t
 
 ```
 
-Load a **full** PATSTAT database and the standardized person table into a `localhost` MySQL database `patstat_2016a`. Again, zipped table files have been placed into the default folder `./data`.
+Load a **full** PATSTAT database and the standardized person table into a `localhost` MySQL database `patstat_2016b`. Again, zipped table files have been placed into the default folder `./data`.
 
 ```
-$ ./load_patstat.sh -u<USER> -p<PASSWORD> -hlocalhost -d patstat_2016a -n
+$ ./load_patstat.sh -u <USER> -p <PASSWORD> -h localhost -d patstat_2016b
 
+```
+
+Example specifying non-default directories for zip files (default `./data`), for
+temporary directory for unzipping (default `/dev/shm`), and for mysql data
+(default `/var/lib/mysql`). Consider using non-default directories if space on
+`/` is limited.
+
+```
+$ ./load_patstat.sh -u <USER> -p <PASSWORD> -h localhost -d patstat_2016b -z /path/to/zipfiles -e /path/to/temp_dir -m /path/to/mysql_data_dir -v
 ```
 
 Troubleshooting

--- a/load_patstat.sh
+++ b/load_patstat.sh
@@ -144,6 +144,7 @@ load_table() {
                LOAD DATA LOCAL INFILE "$UNZIPPEDFILE"
                INTO TABLE $1 FIELDS TERMINATED BY ","
                OPTIONALLY ENCLOSED BY '"'
+               ESCAPED BY ''
                LINES TERMINATED BY '\r\n'
                IGNORE 1 LINES;
                commit;

--- a/load_patstat.sh
+++ b/load_patstat.sh
@@ -205,6 +205,7 @@ function main(){
     load_table tls802_legal_event_code
     load_table tls901_techn_field_ipc
     load_table tls902_ipc_nace2
+    load_table tls904_nuts
     load_table tls203_appln_abstr
     load_table tls221_inpadoc_prs
 

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -61,7 +61,7 @@ CREATE TABLE tls202_appln_title (
 CREATE TABLE tls203_appln_abstr (
   appln_id int(11) NOT NULL DEFAULT '0',
   appln_abstract_lg char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  appln_abstract text COLLATE utf8mb4_unicode_ci,
+  appln_abstract text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (appln_id)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=800;
 
@@ -182,7 +182,7 @@ CREATE TABLE tls212_citation (
 CREATE TABLE tls214_npl_publn (
   npl_publn_id int(11) NOT NULL DEFAULT '0',
   npl_type char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  npl_biblio text COLLATE utf8mb4_unicode_ci NOT NULL,
+  npl_biblio text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (npl_publn_id)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=150;
 
@@ -281,9 +281,9 @@ CREATE TABLE tls226_person_orig (
   source char(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   source_version varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   name_freeform varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  last_name varchar(400) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  first_name varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  middle_name varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  last_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  first_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  middle_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   address_freeform varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   address_1 varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   address_2 varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -327,7 +327,7 @@ CREATE TABLE tls228_docdb_fam_citn (
 
 CREATE TABLE tls229_appln_nace2 (
   appln_id int(11) NOT NULL DEFAULT '0',
-  nace2_code char(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nace2_code varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   weight float NOT NULL DEFAULT '1',
   PRIMARY KEY (appln_id,nace2_code),
   KEY nace2_code (nace2_code)
@@ -345,8 +345,8 @@ CREATE TABLE tls230_appln_techn_field (
 
 
 CREATE TABLE tls801_country (
-  ctry_code varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  iso_alpha3 varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  ctry_code char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  iso_alpha3 char(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   st3_name varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   state_indicator char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   continent varchar(25) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -365,7 +365,7 @@ CREATE TABLE tls802_legal_event_code (
   lec_name varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   nat_auth_cc varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   nat_lec_name varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  impact char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  impact varchar(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   lec_descr varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   lecg_id tinyint(4) NOT NULL DEFAULT '0',
   lecg_name varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -389,19 +389,29 @@ CREATE TABLE tls902_ipc_nace2 (
   ipc varchar(8) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   not_with_ipc varchar(8) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   unless_with_ipc varchar(8) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  nace2_code char(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  nace2_weight float NOT NULL DEFAULT '1',
+  nace2_code varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nace2_weight tinyint NOT NULL DEFAULT '1',
   nace2_descr varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (ipc,not_with_ipc,unless_with_ipc,nace2_code)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ;
 
 
 
+CREATE TABLE tls904_nuts (
+  nuts3 varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nuts3_name varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (nuts3)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ;
+
+
+
 CREATE TABLE tls906_person (
   person_id int(11) NOT NULL DEFAULT '0',
-  person_name varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL,
+  person_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
   person_address varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
   person_ctry_code char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nuts varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nuts_level tinyint NOT NULL DEFAULT '9',
   doc_std_name_id int(11) NOT NULL DEFAULT '0',
   doc_std_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
   psn_id int(11) NOT NULL DEFAULT '0',

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -61,7 +61,7 @@ CREATE TABLE tls202_appln_title (
 CREATE TABLE tls203_appln_abstr (
   appln_id int(11) NOT NULL DEFAULT '0',
   appln_abstract_lg char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  appln_abstract text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  appln_abstract text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (appln_id)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=800;
 
@@ -182,7 +182,7 @@ CREATE TABLE tls212_citation (
 CREATE TABLE tls214_npl_publn (
   npl_publn_id int(11) NOT NULL DEFAULT '0',
   npl_type char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  npl_biblio text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  npl_biblio text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (npl_publn_id)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci  AVG_ROW_LENGTH=150;
 


### PR DESCRIPTION
Hi,

I put these changes in a new branch named 'patstat_2016b'. I don't know if you can merge the changes also in a branch separate from master. Ideal would be to have one branch for each PATSTAT version, to provide easy access to older versions as well.

I added table tls904_nuts that was added in 2016b and also updated the other table schemas based on comparison with the EPO-provided SQL scripts.

I included ESCAPED BY '' in the LOAD DATA LOCAL INFILE command that fixes problems with illegal control characters: There are sometimes backslashes in the data and backslashes with non-ASCII characters behind them were interpreted as (illegal) control characters causing the CSV read-in to stop at that line. This is because every backslash is interpreted as an escape character. ESCAPED BY '' sets the escape character to nothing, which is OK, because EPO says in the "Hints for data loading" that they do not escape any charcaters except line breaking characters ('\n'). So, the only downside is that '\n' is not read in as proper newline, but as-is, which I think is no problem.

I found the suggestion here: http://forums.epo.org/post11651.html#p11651 (already dated back to 2013), see also MySQL docs https://dev.mysql.com/doc/refman/5.7/en/load-data.html for the [ESCAPED BY 'char'] syntax.